### PR TITLE
Update DEPS to include HLS support

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -17,8 +17,8 @@
 # Edit these when rolling DEPS.xwalk.
 # -----------------------------------
 
-chromium_crosswalk_rev = 'a198c470a760f45a855cbd698071b0fc6c08a851'
-nv_chromium_crosswalk_rev = 'a198c470a760f45a855cbd698071b0fc6c08a851'
+# chromium_crosswalk_rev = 'a198c470a760f45a855cbd698071b0fc6c08a851'
+nv_chromium_crosswalk_rev = '564fbd996b6d8945fd10e6e056be01fbece13935'
 v8_crosswalk_rev = 'ef916fcaccd4df07b38abecbbcc023817b4a50e5'
 
 # We need our own copy of src/buildtools in order to have the gn and


### PR DESCRIPTION
Update DEPS to include HLS support from nv-chromium repo
Comment chromium_crosswalk_rev revision-id as it is not required for nv-chromium based library
